### PR TITLE
全角文字とかが混じってると右の棒がバグるのを直した

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+unicode-width = "0.1.7"
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use std::env;
+use unicode_width::UnicodeWidthStr;
 
 const CAT_SUCCESS: &str = r"(=^･ω ･^=)";
 const CAT_FAILED: &str = r"(=^･ｪ･^=)";
@@ -18,7 +19,11 @@ fn main() {
             return;
         }
     }
-    let file_width = file_text.lines().map(|line| line.len()).max().unwrap();
+    let file_width = file_text
+        .lines()
+        .map(|line| UnicodeWidthStr::width(line))
+        .max()
+        .unwrap();
 
     print_cat(&file_text, file_width);
 }
@@ -27,7 +32,7 @@ fn print_cat(file_text: &str, file_width: usize) {
     print_horizontal_bar(file_width);
     for line in file_text.lines() {
         print!("|   {}", line);
-        for _ in 0..(file_width - line.len()) {
+        for _ in 0..(file_width - UnicodeWidthStr::width(line)) {
             print!(" ");
         }
         println!("    |");


### PR DESCRIPTION
fix #1 

![screenshot 2022-11-16 9 27 41](https://user-images.githubusercontent.com/44772513/202053493-3cab59ac-8238-4978-aaeb-bf417bb4c310.png)
![screenshot 2022-11-16 9 29 19](https://user-images.githubusercontent.com/44772513/202053682-33f754a9-0c7a-46a9-b823-ae0e9cd52fa3.png)
